### PR TITLE
Removed jSoup Dependency from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,6 @@
             <version>1.9.0</version>
         </dependency>
         <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.14.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-fontawesome-pack</artifactId>
             <version>12.3.1</version>


### PR DESCRIPTION
jSoup was used during dev for web scraping script. Unneeded.